### PR TITLE
Show battery status in zsh terminal

### DIFF
--- a/.p10k.zsh
+++ b/.p10k.zsh
@@ -104,7 +104,7 @@
     # ip                    # ip address and bandwidth usage for a specified network interface
     # public_ip             # public IP address
     # proxy                 # system-wide http/https/ftp proxy
-    # battery               # internal battery
+    battery                 # internal battery
     # wifi                  # wifi speed
     # example               # example user-defined segment (see prompt_example function below)
   )


### PR DESCRIPTION
What if there is no internal battery, e.g. on a desktop computer?